### PR TITLE
Add b_escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# Disclaimer
-Any invalid reference issue should have a valid case and not a output of your magic fuzzy.
-
 # v_escape [![Documentation](https://docs.rs/v_escape/badge.svg)](https://docs.rs/v_escape/) [![Latest version](https://img.shields.io/crates/v/v_escape.svg)](https://crates.io/crates/v_escape) [![Build Status](https://travis-ci.org/botika/v_escape.svg?branch=master)](https://travis-ci.org/botika/v_escape)
 > The simd optimized escape code
 

--- a/v_escape/Cargo.toml
+++ b/v_escape/Cargo.toml
@@ -15,10 +15,6 @@ workspace = ".."
 travis-ci = { repository = "botika/v_escape", branch = "master" }
 maintenance = { status = "actively-developed" }
 
-[lib]
-name = "v_escape"
-path = "src/lib.rs"
-bench = false
-
 [dependencies]
 v_escape_derive = { version = "0.7", path = "../v_escape_derive" }
+bytes = "0.5"

--- a/v_escape/Cargo.toml
+++ b/v_escape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "v_escape"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Juan Aguilar Santillana <mhpoin@gmail.com>"]
 description = "The simd optimized escaping code"
 documentation = "https://docs.rs/v_escape"
@@ -16,5 +16,5 @@ travis-ci = { repository = "botika/v_escape", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-v_escape_derive = { version = "0.7", path = "../v_escape_derive" }
+v_escape_derive = { version = "0.8", path = "../v_escape_derive" }
 bytes = "0.5"

--- a/v_escape/src/ranges/mod.rs
+++ b/v_escape/src/ranges/mod.rs
@@ -160,7 +160,7 @@ macro_rules! _v_escape_escape_ranges_ptr {
         _v_escape_escape_ranges_ptr!(impl loop_range_switch_sse2 for $($t)+);
     };
     (impl $loops:ident for ($T:ident, $Q:ident, $Q_LEN:ident) $($t:tt)+) => {
-        pub unsafe fn v_escape(bytes: &[u8], buf: &mut [std::mem::MaybeUninit<u8>]) -> Option<usize> {
+        pub unsafe fn f_escape(bytes: &[u8], buf: &mut [std::mem::MaybeUninit<u8>]) -> Option<usize> {
             let mut buf_cur = 0;
 
             let len = bytes.len();
@@ -287,6 +287,144 @@ macro_rules! _v_escape_escape_ranges_ptr {
             }
 
             Some(buf_cur)
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! _v_escape_escape_ranges_bytes {
+    (avx2 $($t:tt)+) => {
+        #[inline]
+        #[target_feature(enable = "avx2")]
+        _v_escape_escape_ranges_bytes!(impl loop_range_switch_avx2 for $($t)+);
+    };
+    (sse2 $($t:tt)+) => {
+        #[inline]
+        #[target_feature(enable = "sse2")]
+        _v_escape_escape_ranges_bytes!(impl loop_range_switch_sse2 for $($t)+);
+    };
+    (impl $loops:ident for ($T:ident, $Q:ident, $Q_LEN:ident) $($t:tt)+) => {
+        pub unsafe fn b_escape(bytes: &[u8], buf: &mut v_escape::BytesMut) {
+            let len = bytes.len();
+            let start_ptr = bytes.as_ptr();
+            let end_ptr = bytes[len..].as_ptr();
+            let mut ptr = start_ptr;
+
+            let mut start = 0;
+
+            macro_rules! mask_bodies_callback {
+                ($callback:ident) => {
+                    // Format bytes in the mask that starts in the current pointer
+                    macro_rules! mask_bodies {
+                        ($mask:ident, $at:ident, $cur:ident, $ptr:ident) => {
+                            // Calls macro `bodies!` at position `$at + $cur`
+                            // of byte `*$ptr` + `$curr` with macro `_v_escape_mask_body!`
+                            $callback!($T, $Q, $Q_LEN, $at + $cur, *$ptr.add($cur), start, bytes, buf, _v_escape_mask_body_bytes);
+
+                            // Create binary vector of all zeros except
+                            // position `$curr` and xor operation with `$mask`
+                            $mask ^= 1 << $cur;
+                            // Test vs Check  if `$mask` is empty
+                            if $mask == 0 {
+                                break;
+                            }
+
+                            // Get to the next possible escape character avoiding zeros
+                            $cur = $mask.trailing_zeros() as usize;
+                        };
+                    }
+                };
+            }
+
+            _v_escape_mask_bodies_escaping_bytes!($($t)+);
+
+            // Macro to write with mask
+            macro_rules! write_mask {
+                ($mask:ident, $ptr:ident) => {{
+                    // Reference to the start of mask
+                    let at = _v_escape_sub!($ptr, start_ptr);
+                    // Get to the first possible escape character avoiding zeros
+                    let mut cur = $mask.trailing_zeros() as usize;
+
+                    loop {
+                        // Writing in `$fmt` with `$mask`
+                        // The main loop will break when mask == 0
+                        mask_bodies!($mask, at, cur, $ptr);
+                    }
+
+                    debug_assert_eq!(at, _v_escape_sub!($ptr, start_ptr))
+                }};
+            }
+
+            // Write a sliced mask
+            macro_rules! write_forward {
+                ($mask: ident, $align:ident) => {{
+                    let at = _v_escape_sub!(ptr, start_ptr);
+                    let mut cur = $mask.trailing_zeros() as usize;
+
+                    while cur < $align {
+                        mask_bodies!($mask, at, cur, ptr);
+                    }
+
+                    debug_assert_eq!(at, _v_escape_sub!(ptr, start_ptr))
+                }};
+            }
+
+            macro_rules! fallback_callback {
+                (default) => {
+                    macro_rules! fallback {
+                        () => {
+                            while ptr < end_ptr {
+                                _v_escape_bodies_bytes!(
+                                    $T,
+                                    $Q,
+                                    $Q_LEN,
+                                    _v_escape_sub!(ptr, start_ptr),
+                                    *ptr,
+                                    start,
+                                    bytes,
+                                    buf,
+                                    _v_escape_mask_body_bytes
+                                );
+                                ptr = ptr.offset(1);
+                            }
+                        };
+                    }
+                };
+                (one) => {
+                    macro_rules! fallback {
+                        () => {
+                            while ptr < end_ptr {
+                                if *ptr == $T {
+                                    _v_escape_bodies_exact_one_bytes!(
+                                        $T,
+                                        $Q,
+                                        $Q_LEN,
+                                        _v_escape_sub!(ptr, start_ptr),
+                                        *ptr,
+                                        start,
+                                        bytes,
+                                        buf,
+                                        _v_escape_mask_body_bytes
+                                    );
+                                }
+                                ptr = ptr.offset(1);
+                            }
+                        };
+                    }
+                };
+            }
+
+            _v_escape_fallback_escaping!($($t)+);
+
+            $loops!((len, ptr, start_ptr, end_ptr) $($t)+);
+
+            // Write since start to the end of the slice
+            debug_assert!(start <= len);
+            if start < len {
+                _v_escape_write_bytes!(&bytes[start..], buf);
+            }
         }
     };
 }

--- a/v_escape/src/ranges/switch.rs
+++ b/v_escape/src/ranges/switch.rs
@@ -463,6 +463,34 @@ macro_rules! _v_escape_mask_bodies_escaping_ptr {
 /// Generate mask bodies callback
 ///
 /// Defining exact match or false positive
+/// ## The following macros must be defined
+///
+/// * `mask_bodies_callback($callback:ident)`
+///     select between `mask_bodies`
+///
+macro_rules! _v_escape_mask_bodies_escaping_bytes {
+    ($fa:expr, 128, ) => {
+        mask_bodies_callback!(_v_escape_bodies_exact_one_bytes);
+    };
+    ($la:expr, $ra:expr, $fb:expr, $fc:expr, 128, ) => {
+        mask_bodies_callback!(_v_escape_bodies_bytes);
+    };
+    ($la:expr, $ra:expr, $lb:expr, $rb:expr, $lc:expr, $rc:expr, ) => {
+        mask_bodies_callback!(_v_escape_bodies_bytes);
+    };
+    ($la:expr, $ra:expr, $lb:expr, $rb:expr, $c:expr, ) => {
+        mask_bodies_callback!(_v_escape_bodies_bytes);
+    };
+    ($($t:tt)+) => {
+        mask_bodies_callback!(_v_escape_bodies_exact_bytes);
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+/// Generate mask bodies callback
+///
+/// Defining exact match or false positive
 ///
 /// ## The following macros must be defined
 ///

--- a/v_escape_derive/Cargo.toml
+++ b/v_escape_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "v_escape_derive"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Juan Aguilar Santillana <mhpoin@gmail.com>"]
 description = "Procedural macro package for v_escape"
 documentation = "https://docs.rs/v_escape_derive"
@@ -14,7 +14,6 @@ workspace = ".."
 [badges]
 travis-ci = { repository = "botika/v_escape", branch = "master" }
 maintenance = { status = "actively-developed" }
-
 
 [lib]
 proc-macro = true

--- a/v_escape_derive/Cargo.toml
+++ b/v_escape_derive/Cargo.toml
@@ -15,11 +15,9 @@ workspace = ".."
 travis-ci = { repository = "botika/v_escape", branch = "master" }
 maintenance = { status = "actively-developed" }
 
+
 [lib]
 proc-macro = true
-name = "v_escape_derive"
-path = "src/lib.rs"
-bench = false
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/v_escape_derive/src/generator.rs
+++ b/v_escape_derive/src/generator.rs
@@ -82,6 +82,7 @@ impl<'a> Generator<'a> {
                     use super::*;
                     _v_escape_escape_char!(one V_ESCAPE_CHAR, V_ESCAPE_QUOTES);
                     _v_escape_escape_char_ptr!(one V_ESCAPE_CHAR, V_ESCAPE_QUOTES);
+                    _v_escape_escape_char_bytes!(one V_ESCAPE_CHAR, V_ESCAPE_QUOTES);
                 }
             )
         } else {
@@ -90,6 +91,7 @@ impl<'a> Generator<'a> {
                     use super::*;
                     _v_escape_escape_char!(V_ESCAPE_TABLE, V_ESCAPE_QUOTES, V_ESCAPE_LEN);
                     _v_escape_escape_char_ptr!(V_ESCAPE_TABLE, V_ESCAPE_QUOTES, V_ESCAPE_LEN);
+                    _v_escape_escape_char_bytes!(V_ESCAPE_TABLE, V_ESCAPE_QUOTES, V_ESCAPE_LEN);
                 }
             )
         };
@@ -103,6 +105,7 @@ impl<'a> Generator<'a> {
                     use super::*;
                     _v_escape_escape_scalar!(one V_ESCAPE_CHAR, V_ESCAPE_QUOTES);
                     _v_escape_escape_scalar_ptr!(one V_ESCAPE_CHAR, V_ESCAPE_QUOTES);
+                    _v_escape_escape_scalar_bytes!(one V_ESCAPE_CHAR, V_ESCAPE_QUOTES);
                 }
             )
         } else {
@@ -111,6 +114,7 @@ impl<'a> Generator<'a> {
                     use super::*;
                     _v_escape_escape_scalar!(V_ESCAPE_TABLE, V_ESCAPE_QUOTES, V_ESCAPE_LEN);
                     _v_escape_escape_scalar_ptr!(V_ESCAPE_TABLE, V_ESCAPE_QUOTES, V_ESCAPE_LEN);
+                    _v_escape_escape_scalar_bytes!(V_ESCAPE_TABLE, V_ESCAPE_QUOTES, V_ESCAPE_LEN);
                 }
             )
         };
@@ -148,6 +152,15 @@ impl<'a> Generator<'a> {
             }
             self.write_macro_tt(buf, ranges);
             buf.writeln(");");
+            buf.write("_v_escape_escape_ranges_bytes!(");
+            buf.write(i);
+            if self.pairs.len() == 1 {
+                buf.write("2 (V_ESCAPE_CHAR, V_ESCAPE_QUOTES, V_ESCAPE_LEN) ");
+            } else {
+                buf.write("2 (V_ESCAPE_TABLE, V_ESCAPE_QUOTES, V_ESCAPE_LEN) ");
+            }
+            self.write_macro_tt(buf, ranges);
+            buf.writeln(");");
             buf.writeln("}");
         }
         buf.writeln("}");
@@ -160,6 +173,10 @@ impl<'a> Generator<'a> {
         ));
         buf.writeln(&format!(
             "_v_escape_cfg_escape_ptr!({}, {});",
+            self.simd, self.avx
+        ));
+        buf.writeln(&format!(
+            "_v_escape_cfg_escape_bytes!({}, {});",
             self.simd, self.avx
         ));
     }

--- a/v_htmlescape/Cargo.toml
+++ b/v_htmlescape/Cargo.toml
@@ -15,11 +15,6 @@ workspace = ".."
 travis-ci = { repository = "botika/v_escape", branch = "master" }
 maintenance = { status = "actively-developed" }
 
-[lib]
-name = "v_htmlescape"
-path = "src/lib.rs"
-bench = false
-
 [dependencies]
 v_escape = { version = "0.10", path = "../v_escape" }
 cfg-if = "0.1"

--- a/v_htmlescape/Cargo.toml
+++ b/v_htmlescape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "v_htmlescape"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Juan Aguilar Santillana <mhpoin@gmail.com>"]
 description = "The simd optimized HTML escaping code"
 documentation = "https://docs.rs/v_htmlescape"
@@ -16,5 +16,5 @@ travis-ci = { repository = "botika/v_escape", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-v_escape = { version = "0.10", path = "../v_escape" }
+v_escape = { version = "0.11", path = "../v_escape" }
 cfg-if = "0.1"

--- a/v_latexescape/Cargo.toml
+++ b/v_latexescape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "v_latexescape"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Juan Aguilar Santillana <mhpoin@gmail.com>"]
 description = "The simd optimized LaTeX escaping code"
 documentation = "https://docs.rs/v_latexescape"
@@ -15,11 +15,6 @@ workspace = ".."
 travis-ci = { repository = "botika/v_escape", branch = "master" }
 maintenance = { status = "actively-developed" }
 
-[lib]
-name = "v_latexescape"
-path = "src/lib.rs"
-bench = false
-
 [dependencies]
-v_escape = { version = "0.10", path = "../v_escape" }
+v_escape = { version = "0.11", path = "../v_escape" }
 cfg-if = "0.1"


### PR DESCRIPTION
Add infallible escape with `bytes::BytesMut`. With new buffer, it can only panic if `src.len() * MAX_QUOTE_LEN >= usize::MAX`