### PR TITLE
Remove `BytesMut` in favor of `buf-min::Buffer` trait

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -51,7 +51,7 @@ jobs:
         timeout-minutes: 40
         with:
           command: test
-          args: --all --all-features --no-fail-fast -- --nocapture
+          args: --all --no-fail-fast -- --nocapture
 
       - name: Install cargo-cache
         continue-on-error: true

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --all-features --no-fail-fast -- --nocapture
+          args: --all --no-fail-fast -- --nocapture
 
       - name: Clear the cargo caches
         run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ script:
       cargo fmt -- --check
     fi
   - cargo check --all
-  - cargo test --all-features --all -- --nocapture
+  - cargo test --all -- --nocapture

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,4 +59,4 @@ build: false
 test_script:
   - cargo clean
   - cargo check --all
-  - cargo test --all-features --all -- --nocapture
+  - cargo test --all -- --nocapture

--- a/v_escape/Cargo.toml
+++ b/v_escape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "v_escape"
-version = "0.11.3"
+version = "0.12.0"
 authors = ["Juan Aguilar Santillana <mhpoin@gmail.com>"]
 description = "The simd optimized escaping code"
 documentation = "https://docs.rs/v_escape"
@@ -15,6 +15,14 @@ workspace = ".."
 travis-ci = { repository = "botika/v_escape", branch = "master" }
 maintenance = { status = "actively-developed" }
 
+[features]
+default = ["bytes-buf"]
+bytes-buf = ["buf-min/bytes-buf"]
+
 [dependencies]
 v_escape_derive = { version = "0.8", path = "../v_escape_derive" }
+buf-min = "0.1"
+
+[dev-dependencies]
 bytes = "0.5"
+buf-min = { version = "0.1", features = ["bytes-buf"] }

--- a/v_escape/build.rs
+++ b/v_escape/build.rs
@@ -1,0 +1,13 @@
+fn main() {
+    enable_simd_optimizations();
+}
+
+fn enable_simd_optimizations() {
+    if is_x86_feature_detected!("sse2") {
+        println!("cargo:rustc-cfg=v_escape_sse");
+    }
+
+    if is_x86_feature_detected!("avx2") {
+        println!("cargo:rustc-cfg=v_escape_avx");
+    }
+}

--- a/v_escape/src/chars.rs
+++ b/v_escape/src/chars.rs
@@ -75,7 +75,7 @@ macro_rules! _v_escape_escape_char_ptr {
 #[doc(hidden)]
 macro_rules! _v_escape_escape_char_bytes {
     ($($t:tt)+) => {
-        pub unsafe fn b_escape_char(c: char, buf: &mut v_escape::BytesMut) {
+        pub unsafe fn b_escape_char<B: v_escape::Buffer>(c: char, buf: &mut B) {
             let len = c.len_utf8();
             buf.reserve(len);
             if len == 1 {
@@ -97,11 +97,11 @@ macro_rules! _v_escape_escape_char_bytes {
                 }
 
                 _inside!(impl $($t)+);
-                *buf.as_mut_ptr().add(buf.len()) = c as u8;
+                *buf.buf_ptr() = c as u8;
             } else {
-                c.encode_utf8(std::slice::from_raw_parts_mut(buf.as_mut_ptr().add(buf.len()), len));
+                c.encode_utf8(std::slice::from_raw_parts_mut(buf.buf_ptr(), len));
             }
-            v_escape::BufMut::advance_mut(buf, len);
+            buf.advance(len);
         }
     };
 }

--- a/v_escape/src/ranges/mod.rs
+++ b/v_escape/src/ranges/mod.rs
@@ -305,7 +305,7 @@ macro_rules! _v_escape_escape_ranges_bytes {
         _v_escape_escape_ranges_bytes!(impl loop_range_switch_sse2 for $($t)+);
     };
     (impl $loops:ident for ($T:ident, $Q:ident, $Q_LEN:ident) $($t:tt)+) => {
-        pub unsafe fn b_escape(bytes: &[u8], buf: &mut v_escape::BytesMut) {
+        pub unsafe fn b_escape<B: v_escape::Buffer>(bytes: &[u8], buf: &mut B) {
             let len = bytes.len();
             let start_ptr = bytes.as_ptr();
             let end_ptr = bytes[len..].as_ptr();

--- a/v_escape/src/scalar.rs
+++ b/v_escape/src/scalar.rs
@@ -115,7 +115,7 @@ macro_rules! _v_escape_escape_scalar_ptr {
 macro_rules! _v_escape_escape_scalar_bytes {
     ($($t:tt)+) => {
         #[inline]
-        pub unsafe fn b_escape(bytes: &[u8], buf: &mut v_escape::BytesMut) {
+        pub unsafe fn b_escape<B: v_escape::Buffer>(bytes: &[u8], buf: &mut B) {
             let mut start = 0;
 
             for (i, b) in bytes.iter().enumerate() {

--- a/v_htmlescape/Cargo.toml
+++ b/v_htmlescape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "v_htmlescape"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Juan Aguilar Santillana <mhpoin@gmail.com>"]
 description = "The simd optimized HTML escaping code"
 documentation = "https://docs.rs/v_htmlescape"
@@ -15,6 +15,10 @@ workspace = ".."
 travis-ci = { repository = "botika/v_escape", branch = "master" }
 maintenance = { status = "actively-developed" }
 
+[features]
+default = ["bytes-buf"]
+bytes-buf = ["v_escape/bytes-buf"]
+
 [dependencies]
-v_escape = { version = "0.11", path = "../v_escape" }
+v_escape = { version = "0.12", path = "../v_escape", default-features = false }
 cfg-if = "0.1"

--- a/v_jsonescape/Cargo.toml
+++ b/v_jsonescape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "v_jsonescape"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Juan Aguilar Santillana <mhpoin@gmail.com>"]
 description = "The simd optimized JSON escaping code"
 documentation = "https://docs.rs/v_jsonescape"
@@ -15,6 +15,10 @@ workspace = ".."
 travis-ci = { repository = "botika/v_escape", branch = "master" }
 maintenance = { status = "actively-developed" }
 
+[features]
+default = ["bytes-buf"]
+bytes-buf = ["v_escape/bytes-buf"]
+
 [dependencies]
-v_escape = { version = "0.11", path = "../v_escape" }
+v_escape = { version = "0.12", path = "../v_escape", default-features = false }
 cfg-if = "0.1"

--- a/v_latexescape/Cargo.toml
+++ b/v_latexescape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "v_latexescape"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Juan Aguilar Santillana <mhpoin@gmail.com>"]
 description = "The simd optimized LaTeX escaping code"
 documentation = "https://docs.rs/v_latexescape"
@@ -15,6 +15,10 @@ workspace = ".."
 travis-ci = { repository = "botika/v_escape", branch = "master" }
 maintenance = { status = "actively-developed" }
 
+[features]
+default = ["bytes-buf"]
+bytes-buf = ["v_escape/bytes-buf"]
+
 [dependencies]
-v_escape = { version = "0.11", path = "../v_escape" }
+v_escape = { version = "0.12", path = "../v_escape", default-features = false }
 cfg-if = "0.1"


### PR DESCRIPTION
Remove at `b_escape`,  `detect` in runtime cpu feature in favor of **`SIGILL`**. When compile to target arch `x86_64` and target features `avx2` and `sse2`:
####  make sure execute the binary in a cpu with `avx2` and `sse2` features, in another case can **SIGILL**.

At the moment it is impossible to create multiple static variables by type.
https://github.com/rust-lang/rust/issues/57775